### PR TITLE
Adding requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,4 +8,5 @@ setup(name='geoplotlib',
       author='Andrea Cuttone',
       author_email='andreacuttone@gmail.com',
       url='https://github.com/andrea-cuttone/geoplotlib',
+      install_requires=['numpy>=1.12','pyglet>=1.2.4']   
 )


### PR DESCRIPTION
Adding in requirements to setup.py such that failures don't occur on install when numpy or pyglet aren't present