### PR TITLE
add check for empty geometry data in geojsonlayer

### DIFF
--- a/geoplotlib/layers.py
+++ b/geoplotlib/layers.py
@@ -937,7 +937,7 @@ class GeoJSONLayer(BaseLayer):
         self.boundingbox = None
         
         for feature in self.data['features']:
-            if not feature['geometry']:
+            if feature['geometry'] is None:
                 print('feature without geometry data: %s' % feature['properties']['NAME'])
                 continue
                 

--- a/geoplotlib/layers.py
+++ b/geoplotlib/layers.py
@@ -937,6 +937,10 @@ class GeoJSONLayer(BaseLayer):
         self.boundingbox = None
         
         for feature in self.data['features']:
+            if not feature['geometry']:
+                print('feature without geometry data: %s' % feature['properties']['NAME'])
+                continue
+                
             if feature['geometry']['type'] == 'Polygon':
                 for poly in feature['geometry']['coordinates']: 
                     poly = np.array(poly)


### PR DESCRIPTION
GeoJson files might have empty geometry fields. This means that the GeoJsonLayer will lead to a `TypeError: 'NoneType' object is not subscriptable` Exception without any indicator on what is wrong.

This "ignores" the features without geometry data while giving the user a hint that his dataset contains features without geometry data.

Code snippet used to find the problem:
```python
with open('data/...') as fin:
    json_data = json.load(fin)
    
    feature_tmp = None
    
    try:
        for feature in json_data['features']:
            feature_tmp = feature
            if feature['geometry']['type'] == 'Polygon':
                for poly in feature['geometry']['coordinates']: 
                    print('valid')
    except Exception:
        print(feature_tmp)
```

Found this:
```
{
	"type": "Feature",
	"properties": {
		"OBJECTID": 42,
		"NAME": "...",
		"Shape__Area": null,
		"Shape__Length": null
	},
	"geometry": null
}
```