### PR TITLE
Adds encoding support to ShapeFileLayers

### DIFF
--- a/geoplotlib/__init__.py
+++ b/geoplotlib/__init__.py
@@ -135,7 +135,7 @@ def graph(data, src_lat, src_lon, dest_lat, dest_lon, linewidth=1, alpha=220, co
     _global_config.layers.append(GraphLayer(data, src_lat, src_lon, dest_lat, dest_lon, linewidth, alpha, color))
 
 
-def shapefiles(fname, f_tooltip=None, color=None, linewidth=3, shape_type='full'):
+def shapefiles(fname, f_tooltip=None, color=None, linewidth=3, shape_type='full', encoding='utf-8', encodingErrors='strict'):
     """
     Load and draws shapefiles
 
@@ -146,7 +146,7 @@ def shapefiles(fname, f_tooltip=None, color=None, linewidth=3, shape_type='full'
     :param shape_type: either full or bbox
     """
     from geoplotlib.layers import ShapefileLayer
-    _global_config.layers.append(ShapefileLayer(fname, f_tooltip, color, linewidth, shape_type))
+    _global_config.layers.append(ShapefileLayer(fname, f_tooltip, color, linewidth, shape_type, encoding, encodingErrors))
 
 
 def voronoi(data, line_color=None, line_width=2, f_tooltip=None, cmap=None, max_area=1e4, alpha=220):

--- a/geoplotlib/layers.py
+++ b/geoplotlib/layers.py
@@ -290,7 +290,7 @@ class GraphLayer(BaseLayer):
 
 class ShapefileLayer(BaseLayer):
 
-    def __init__(self, fname, f_tooltip=None, color=None, linewidth=3, shape_type='full'):
+    def __init__(self, fname, f_tooltip=None, color=None, linewidth=3, shape_type='full', encoding='utf-8', encodingErrors='strict'):
         """
         Loads and draws shapefiles
 
@@ -312,7 +312,7 @@ class ShapefileLayer(BaseLayer):
         except:
             raise Exception('ShapefileLayer requires pyshp')
 
-        self.reader = shapefile.Reader(fname)
+        self.reader = shapefile.Reader(fname, encoding=encoding, encodingErrors=encodingErrors)
         self.worker = None
         self.queue = Queue.Queue()
 


### PR DESCRIPTION
**pyshp Reader** allow us to set what type of encoding should be used when reading a shape file. Geoplotlib wrapper does not contain this parameters which are very useful. This PR adds this features to the wrapper and uses the same default values from pyshp when they are not provided by the users.

- See: https://github.com/GeospatialPython/pyshp/blob/master/shapefile.py