### PR TITLE
Change import of pylab, changed import statement

### DIFF
--- a/geoplotlib/colors.py
+++ b/geoplotlib/colors.py
@@ -1,6 +1,8 @@
 from random import shuffle
 import math
 
+from matplotlib.pylab import get_cmap
+
 
 def _convert_color_format(col, alpha):
     return [int(c * 255) for c in col[:3]] + [alpha]
@@ -15,7 +17,7 @@ class ColorMap():
         :param alpha: color alpha
         :param levels: discretize the colorscale into levels
         """
-        from pylab import get_cmap
+
         self.cmap = get_cmap(cmap_name)
         self.alpha = alpha
         self.levels = levels


### PR DESCRIPTION
Using the ColorMap in the current version leads to an error:

Example: 
```python
# converting the obesity into a color
cmap = ColorMap('Reds', alpha=255, levels=40)

def get_color(properties):
    return cmap.to_color(properties['Obesity'], maxvalue=40,scale='lin')
```

---

```bash
ImportError: cannot import name 'get_cmap' from 'pylab' (/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/pylab/__init__.py)
```

Since the import has changed from

```python
from pylab import get_cmap
```

to 

```python
from matplotlib.pylab import get_cmap
```

Any chance we could update this and publish the new version to PyPi, @andrea-cuttone ? 😊 