### PR TITLE
Fixes #17 - Marker's anchors are now integers

### DIFF
--- a/geoplotlib/layers.py
+++ b/geoplotlib/layers.py
@@ -677,8 +677,8 @@ class MarkersLayer(BaseLayer):
         self.f_tooltip = f_tooltip
         self.marker_preferred_size = float(marker_preferred_size)
         self.marker = pyglet.image.load(marker)
-        self.marker.anchor_x = self.marker.width / 2
-        self.marker.anchor_y = self.marker.height / 2
+        self.marker.anchor_x = self.marker.width // 2
+        self.marker.anchor_y = self.marker.height // 2
         self.scale = self.marker_preferred_size / max(self.marker.width, self.marker.height)
 
         self.hotspots = HotspotManager()


### PR DESCRIPTION
Hi Andrea :)

I ran into the issue described in #17 and I managed to solve it.

From the specs of pyglet's [ImageData](https://pythonhosted.org/pyglet/api/pyglet.image.ImageData-class.html), I noticed that both `anchor_x` and `anchor_y` are expected to be `int`. Therefore I forced an integer division by using the [floor division](http://docs.python.org/release/2.2.3/whatsnew/node7.html) operator to ensure that the result matches the expected type.

I hope it can help!
Thanks for the library :)
