### PR TITLE
remove use_2to3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='geoplotlib',
-      use_2to3=True,
+      use_2to3=False,
       packages=['geoplotlib'],
       version='0.3.2',
       description='python toolbox for geographic visualizations',


### PR DESCRIPTION
This package already supports python3. Removing the use_2to3 reference will allow this package to be installed via pip after the use_2to3 feature was removed in setuptools 58

https://setuptools.readthedocs.io/en/latest/history.html#v58-0-0